### PR TITLE
feat: add fail-fast mode to move test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12730,6 +12730,7 @@ dependencies = [
  "rayon",
  "regex",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -543,6 +543,10 @@ pub struct TestPackage {
     /// Dump storage state on failure.
     #[clap(long = "dump")]
     pub dump_state: bool,
+
+    /// Fail-fast mode: stop running tests after the first failure.
+    #[clap(long = "fail-fast")]
+    pub fail_fast: bool,
 }
 
 pub(crate) fn fix_bytecode_version(
@@ -614,6 +618,7 @@ impl CliCommand<&'static str> for TestPackage {
                         )
                     })
                     .collect(),
+                fail_fast: self.fail_fast,
                 ..UnitTestingConfig::default()
             },
             // TODO(Gas): we may want to switch to non-zero costs in the future

--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -283,7 +283,14 @@ pub fn run_move_unit_tests_with_factory<W: Write + Send, F: UnitTestFactory + Se
     // Run the tests. If any of the tests fail, then we don't produce a coverage report, so cleanup
     // the trace files.
     if !unit_test_config
-        .run_and_report_unit_tests(test_plan, Some(natives), Some(genesis), writer, factory)
+        .run_and_report_unit_tests(
+            test_plan,
+            Some(natives),
+            Some(genesis),
+            writer,
+            factory,
+            unit_test_config.fail_fast,
+        )
         .unwrap()
         .1
     {

--- a/third_party/move/tools/move-unit-test/Cargo.toml
+++ b/third_party/move/tools/move-unit-test/Cargo.toml
@@ -35,6 +35,7 @@ move-vm-types = { workspace = true }
 once_cell = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 datatest-stable = { workspace = true }

--- a/third_party/move/tools/move-unit-test/src/lib.rs
+++ b/third_party/move/tools/move-unit-test/src/lib.rs
@@ -97,6 +97,10 @@ pub struct UnitTestingConfig {
     /// Verbose mode
     #[clap(short = 'v', long = "verbose")]
     pub verbose: bool,
+
+    /// Fail Fast mode: stop at the first test failure
+    #[clap(long = "fail-fast")]
+    pub fail_fast: bool,
 }
 
 fn format_module_id(module_id: &ModuleId) -> String {
@@ -121,6 +125,7 @@ impl Default for UnitTestingConfig {
             verbose: false,
             list: false,
             named_address_values: vec![],
+            fail_fast: false,
         }
     }
 }
@@ -186,6 +191,7 @@ impl UnitTestingConfig {
         genesis_state: Option<ChangeSet>,
         writer: W,
         factory: F,
+        fail_fast: bool,
     ) -> Result<(W, bool)> {
         let shared_writer = Mutex::new(writer);
         let shared_options = Mutex::new(factory);
@@ -213,6 +219,7 @@ impl UnitTestingConfig {
             native_function_table,
             genesis_state,
             self.verbose,
+            fail_fast,
         )
         .unwrap();
 

--- a/third_party/move/tools/move-unit-test/src/main.rs
+++ b/third_party/move/tools/move-unit-test/src/main.rs
@@ -16,6 +16,7 @@ pub fn main() {
             None,
             std::io::stdout(),
             UnitTestFactoryWithCostTable::new(None, None),
+            args.fail_fast,
         )
         .unwrap();
     }

--- a/third_party/move/tools/move-unit-test/src/test_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/test_runner.rs
@@ -210,7 +210,7 @@ impl TestRunner {
                         .map(|(_, test_plan)| {
                             self.testing_config
                                 .exec_module_tests(test_plan, writer, options, false)
-                                .unwrap() // cannot fail in non-fail-fast mode
+                                .expect("exec_module_tests should not fail in non-fail-fast mode")
                         })
                         .reduce(TestStatistics::new, |acc, stats| acc.combine(stats));
 

--- a/third_party/move/tools/move-unit-test/src/test_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/test_runner.rs
@@ -173,6 +173,9 @@ impl TestRunner {
             .build()
             .unwrap()
             .install(|| {
+                // we do a try_reduce so that we can short-circuit on fail-fast
+                // if not in fail-fast mode, we expect no errors at all
+                // if in fail-fast mode, we expect only FailFast errors
                 let stats = self
                     .tests
                     .module_tests
@@ -181,18 +184,17 @@ impl TestRunner {
                         self.testing_config.exec_module_tests( plan, writer, options)
                     })
                     .try_reduce(TestStatistics::new, |a, b| Ok(a.combine(b)));
-                // If we got an error, it must be a fail-fast error, so extract the stats until the first failure.
-                let final_stats = match stats {
-                    Err(e) if !self.testing_config.fail_fast => panic!("We expect no errors at all when not in fail-fast mode, but got: {:?}", e),
-                    Err(e) => {
-                        if let Some(fail_fast) = e.downcast_ref::<FailFast>() {
-                            fail_fast.0.clone()
-                        } else {
-                            panic!("Only FailFast errors are expected in fail-fast mode, but got a different error: {:?}", e);
-                        }
-                    },
-                    Ok(stats) => stats,
-                };
+
+                let final_stats = stats.unwrap_or_else(|e| {
+                    if !self.testing_config.fail_fast {
+                        panic!("We expect no errors at all when not in fail-fast mode, but got: {:?}", e);
+                    }
+                    e.downcast_ref::<FailFast>().map(|fail_fast| {
+                        fail_fast.0.clone() // The error wraps the stats up to the first failure
+                    }).unwrap_or_else(|| {
+                        panic!("Only FailFast errors are expected in fail-fast mode, but got a different error: {:?}", e);
+                    })
+                });
 
                 Ok(TestResults::new(final_stats, self.tests))
             })

--- a/third_party/move/tools/move-unit-test/src/test_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/test_runner.rs
@@ -178,12 +178,7 @@ impl TestRunner {
                     .module_tests
                     .par_iter()
                     .map(|(_, plan)| {
-                        self.testing_config.exec_module_tests(
-                            plan,
-                            writer,
-                            options,
-                            self.testing_config.fail_fast,
-                        )
+                        self.testing_config.exec_module_tests( plan, writer, options)
                     })
                     .try_reduce(TestStatistics::new, |a, b| Ok(a.combine(b)));
                 // If we got an error, it must be a fail-fast error, so extract the stats until the first failure.
@@ -356,7 +351,6 @@ impl SharedTestingConfig {
         test_plan: &ModuleTestPlan,
         output: &TestOutput<impl Write>,
         factory: &Mutex<F>,
-        fail_fast: bool,
     ) -> Result<TestStatistics> {
         let mut stats = TestStatistics::new();
 
@@ -429,7 +423,7 @@ impl SharedTestingConfig {
                                 ),
                                 test_plan,
                             );
-                            if fail_fast {
+                            if self.fail_fast {
                                 return Err(FailFast(stats).into());
                             }
                         },
@@ -447,7 +441,7 @@ impl SharedTestingConfig {
                                 ),
                                 test_plan,
                             );
-                            if fail_fast {
+                            if self.fail_fast {
                                 return Err(FailFast(stats).into());
                             }
                         },
@@ -463,7 +457,7 @@ impl SharedTestingConfig {
                                 ),
                                 test_plan,
                             );
-                            if fail_fast {
+                            if self.fail_fast {
                                 return Err(FailFast(stats).into());
                             }
                         },
@@ -478,7 +472,7 @@ impl SharedTestingConfig {
                                 ),
                                 test_plan,
                             );
-                            if fail_fast {
+                            if self.fail_fast {
                                 return Err(FailFast(stats).into());
                             }
                         },
@@ -514,9 +508,8 @@ impl SharedTestingConfig {
         test_plan: &ModuleTestPlan,
         writer: &Mutex<impl Write>,
         factory: &Mutex<F>,
-        fail_fast: bool,
     ) -> Result<TestStatistics> {
         let output = TestOutput { test_plan, writer };
-        self.exec_module_tests_move_vm_and_stackless_vm(test_plan, &output, factory, fail_fast)
+        self.exec_module_tests_move_vm_and_stackless_vm(test_plan, &output, factory)
     }
 }

--- a/third_party/move/tools/move-unit-test/src/test_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/test_runner.rs
@@ -189,7 +189,7 @@ impl TestRunner {
                             if let Some(fail_fast) = e.downcast_ref::<FailFast>() {
                                 fail_fast.0.clone()
                             } else {
-                                panic!("unexpected error: {:?}", e);
+                                panic!("Only FailFast errors are expected in fail-fast mode, but got a different error: {:?}", e);
                             }
                         },
                         Ok(stats) => stats,

--- a/third_party/move/tools/move-unit-test/src/test_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/test_runner.rs
@@ -168,55 +168,39 @@ impl TestRunner {
         writer: &Mutex<W>,
         options: &Mutex<F>,
     ) -> Result<TestResults> {
-        if self.testing_config.fail_fast {
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(self.num_threads)
-                .build()
-                .unwrap()
-                .install(|| {
-                    let stats = self
-                        .tests
-                        .module_tests
-                        .par_iter()
-                        .map(|(_, plan)| {
-                            self.testing_config
-                                .exec_module_tests(plan, writer, options, true)
-                        })
-                        .try_reduce(TestStatistics::new, |a, b| Ok(a.combine(b)));
-                    // If we got an error, it must be a fail-fast error, so extract the stats until the first failure.
-                    let final_stats = match stats {
-                        Err(e) => {
-                            if let Some(fail_fast) = e.downcast_ref::<FailFast>() {
-                                fail_fast.0.clone()
-                            } else {
-                                panic!("Only FailFast errors are expected in fail-fast mode, but got a different error: {:?}", e);
-                            }
-                        },
-                        Ok(stats) => stats,
-                    };
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(self.num_threads)
+            .build()
+            .unwrap()
+            .install(|| {
+                let stats = self
+                    .tests
+                    .module_tests
+                    .par_iter()
+                    .map(|(_, plan)| {
+                        self.testing_config.exec_module_tests(
+                            plan,
+                            writer,
+                            options,
+                            self.testing_config.fail_fast,
+                        )
+                    })
+                    .try_reduce(TestStatistics::new, |a, b| Ok(a.combine(b)));
+                // If we got an error, it must be a fail-fast error, so extract the stats until the first failure.
+                let final_stats = match stats {
+                    Err(e) if !self.testing_config.fail_fast => panic!("We expect no errors at all when not in fail-fast mode, but got: {:?}", e),
+                    Err(e) => {
+                        if let Some(fail_fast) = e.downcast_ref::<FailFast>() {
+                            fail_fast.0.clone()
+                        } else {
+                            panic!("Only FailFast errors are expected in fail-fast mode, but got a different error: {:?}", e);
+                        }
+                    },
+                    Ok(stats) => stats,
+                };
 
-                    Ok(TestResults::new(final_stats, self.tests))
-                })
-        } else {
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(self.num_threads)
-                .build()
-                .unwrap()
-                .install(|| {
-                    let final_statistics = self
-                        .tests
-                        .module_tests
-                        .par_iter()
-                        .map(|(_, test_plan)| {
-                            self.testing_config
-                                .exec_module_tests(test_plan, writer, options, false)
-                                .expect("exec_module_tests should not fail in non-fail-fast mode")
-                        })
-                        .reduce(TestStatistics::new, |acc, stats| acc.combine(stats));
-
-                    Ok(TestResults::new(final_statistics, self.tests))
-                })
-        }
+                Ok(TestResults::new(final_stats, self.tests))
+            })
     }
 
     pub fn filter(&mut self, test_name_slice: &str) {

--- a/third_party/move/tools/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/third_party/move/tools/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -55,6 +55,7 @@ fn run_test_with_modifiers(
                     None,
                     buffer,
                     UnitTestFactoryWithCostTable::new(None, None),
+                    unit_test_config.fail_fast,
                 )?,
                 modified_exp_path,
             ))
@@ -75,6 +76,7 @@ fn run_test_with_modifiers(
             None,
             buffer,
             UnitTestFactoryWithCostTable::new(None, None),
+            unit_test_config.fail_fast,
         )?,
         path.with_extension(exp_ext),
     ));


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR adds a `fail-fast` flag to `aptos move test`. The rationale is that for the move-mutation-tool, it's beneficial to stop unit tests after the first failure as this indicates that the mutant should be killed, and avoids wasting CPU cycles on this mutant.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Tested manually by running `aptos move test` with and without the `--fail-fast` flag.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
